### PR TITLE
Create destroy

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,0 +1,1 @@
+true:debug

--- a/lib/libmakergame.cpp
+++ b/lib/libmakergame.cpp
@@ -35,14 +35,13 @@ void draw_sprite(sf::Sprite *sprite) { window.draw(*sprite); }
 
 void end_game() { close_window(&window); game_ended = true; }
 
-void main_create();
-void main_step();
-void main_destroy();
-void main_draw();
+void global_create();
+void global_step();
+void global_draw();
 }
 
 int main() {
-  main_create();
+  global_create();
   if (game_ended) return 0;
 
   window.create(sf::VideoMode(800, 600), "Hello World");
@@ -54,12 +53,10 @@ int main() {
       if (event.type == sf::Event::Closed)
         window.close();
     }
-    main_step();
+    global_step();
     window.clear();
-    main_draw();
+    global_draw();
     window.display();
   }
-
-  main_destroy();
   return 0;
 }

--- a/lib/libmakergame.cpp
+++ b/lib/libmakergame.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Graphics.hpp>
 #include <map>
 #include <string>
+#include <iostream>
 
 static std::map<std::string, sf::Texture> image_map;
 static sf::RenderWindow window;
@@ -21,10 +22,9 @@ static bool game_ended = false;
 extern "C" {
 
 sf::Sprite *load_image(const char *filename) {
-  auto result = image_map.emplace(std::make_pair(filename, sf::Texture()));
-  if (!result.second)
-    result.first->second.loadFromFile(filename);
-  return new sf::Sprite(result.first->second);
+  if (!image_map.count(filename) && !image_map[filename].loadFromFile(filename))
+    std::cerr << "unable to load image " << filename << "\n";
+  return new sf::Sprite(image_map[filename]);
 }
 
 void set_sprite_position(sf::Sprite *sprite, double x, double y) {

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -146,6 +146,8 @@ let rec string_of_expr = function
   | Assign((v, c), e) -> (String.concat "." (v :: c)) ^ " = " ^ string_of_expr e
   | Call(f, el) ->
       f ^ "(" ^ String.concat ", " (List.map string_of_expr el) ^ ")"
+  | Create o -> "create " ^ o   (* TODO: precedence? parentheses? *)
+  | Destroy o -> "destroy " ^ (string_of_expr o) (* TODO: ibid *)
   | Noexpr -> ""
 
 let rec string_of_stmt = function

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -28,6 +28,8 @@ type expr =
   | Unop of uop * typ * expr
   | Assign of (string * string list) * expr
   | Call of string * expr list
+  | Create of string
+  | Destroy of expr
   | Noexpr
 
 type stmt =

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -24,8 +24,8 @@ type expr =
   | FloatLit of float
   | StringLit of string
   | Id of string * string list
-  | Binop of expr * op * expr
-  | Unop of uop * expr
+  | Binop of expr * op * typ * expr
+  | Unop of uop * typ * expr
   | Assign of (string * string list) * expr
   | Call of string * expr list
   | Noexpr
@@ -138,9 +138,9 @@ let rec string_of_expr = function
   | BoolLit(true) -> "true"
   | BoolLit(false) -> "false"
   | Id(s, c) -> String.concat "." (s :: c)
-  | Binop(e1, o, e2) ->
+  | Binop(e1, o, _, e2) ->
       string_of_expr e1 ^ " " ^ string_of_op o ^ " " ^ string_of_expr e2
-  | Unop(o, e) -> string_of_uop o ^ string_of_expr e
+  | Unop(o, _, e) -> string_of_uop o ^ string_of_expr e
   | Assign((v, c), e) -> (String.concat "." (v :: c)) ^ " = " ^ string_of_expr e
   | Call(f, el) ->
       f ^ "(" ^ String.concat ", " (List.map string_of_expr el) ^ ")"

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -152,7 +152,7 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
       | A.FloatLit f -> L.const_float float_t f
       | A.Noexpr -> L.const_int i32_t 0
       | A.Id (hd, tl) -> L.build_load (lookup builder scope hd tl) hd builder
-      | A.Binop (e1, op, e2) ->
+      | A.Binop (e1, op, _, e2) ->
         let e1' = expr builder e1
         and e2' = expr builder e2 in
         (match op with
@@ -171,7 +171,7 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
          | A.Greater -> L.build_icmp L.Icmp.Sgt
          | A.Geq     -> L.build_icmp L.Icmp.Sge
         ) e1' e2' "tmp" builder
-      | A.Unop(op, e) ->
+      | A.Unop(op, _, e) ->
         let e' = expr builder e in
         (match op with
            A.Neg     -> L.build_neg

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -135,7 +135,7 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
     let builder = L.builder_at_end context (L.entry_block f) in
     let node = L.param f 0 in
     let _ =
-      let destroy_event = L.build_load (L.build_struct_gep node 2 "" builder) "event" builder in
+      let destroy_event = L.build_load (L.build_struct_gep node 3 "" builder) "event" builder in
       L.build_call destroy_event [|node|] "" builder
     in
     let gameobj = L.build_load (L.build_struct_gep node 0 "" builder) "obj" builder in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -36,12 +36,24 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
     in
     List.fold_left lltype_of StringMap.empty gameobjs
   in
+
   let gameobj_t = L.pointer_type (L.named_struct_type context "gameobj") in
-  let node_t =
-    let t = L.named_struct_type context "node" in
-    let eventptr_t = L.pointer_type (L.function_type void_t [|gameobj_t|]) in
-    L.struct_set_body t [|gameobj_t; eventptr_t; eventptr_t; eventptr_t; eventptr_t; L.pointer_type t; L.pointer_type t|] false;
-    t
+  let node_t = L.named_struct_type context "node" in
+  let eventptr_t = L.pointer_type (L.function_type void_t [|L.pointer_type node_t|]) in
+  L.struct_set_body node_t
+    [|gameobj_t; eventptr_t; eventptr_t; eventptr_t; eventptr_t;
+      L.pointer_type node_t; L.pointer_type node_t|] false;
+
+  let node_head =
+    let n = L.declare_global node_t "node_head" the_module in
+    L.set_initializer (L.const_named_struct node_t
+                         [|L.const_null gameobj_t;
+                           L.const_null eventptr_t;
+                           L.const_null eventptr_t;
+                           L.const_null eventptr_t;
+                           L.const_null eventptr_t;
+                           n; n|]) n;
+    n
   in
 
   let ltype_of_typ = function
@@ -87,6 +99,60 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
   let printf_t = L.var_arg_function_type i32_t [| L.pointer_type i8_t |] in
   let printf_func = L.declare_function "printf" printf_t the_module in
 
+  let create_func =
+    let f =
+      let t =
+        L.function_type (L.pointer_type node_t)
+          [|gameobj_t; eventptr_t; eventptr_t; eventptr_t; eventptr_t|]
+      in
+      L.define_function "create" t the_module
+    in
+    let builder = L.builder_at_end context (L.entry_block f) in
+    let node = L.build_malloc node_t "node" builder in
+    let following_prev_ptr = L.build_struct_gep node_head 5 "prev_ptr" builder in
+    let fprev = L.build_load following_prev_ptr "prev" builder in
+    let preceding_next_ptr = L.build_struct_gep fprev 6 "next_ptr" builder in
+    let pnext = L.build_load preceding_next_ptr "next" builder in
+    let _ = L.build_store node following_prev_ptr builder in
+    let _ = L.build_store node preceding_next_ptr builder in
+    let assign ind param =
+      let elem = L.build_struct_gep node ind "" builder in
+      L.build_store param elem builder
+    in
+    ignore (Array.mapi assign (Array.append (L.params f) [|fprev; pnext|]));
+    let _ =
+      let create_event = L.param f 1 in
+      L.build_call create_event [|node|] "" builder
+    in
+    ignore (L.build_ret node builder);
+    f
+  in
+
+  let destroy_func =
+    let f =
+      let t = L.function_type void_t [|L.pointer_type node_t|] in
+      L.define_function "destroy" t the_module
+    in
+    let builder = L.builder_at_end context (L.entry_block f) in
+    let node = L.param f 0 in
+    let _ =
+      let destroy_event = L.build_load (L.build_struct_gep node 2 "" builder) "event" builder in
+      L.build_call destroy_event [|node|] "" builder
+    in
+    let gameobj = L.build_load (L.build_struct_gep node 0 "" builder) "obj" builder in
+    let _ = L.build_free gameobj builder in
+    let prev_ptr = L.build_struct_gep node 5 "prev_ptr" builder in
+    let prev = L.build_load prev_ptr "prev" builder in
+    let next_ptr = L.build_struct_gep node 6 "next_ptr" builder in
+    let next = L.build_load next_ptr "next" builder in
+    let next_prev = L.build_struct_gep next 5 "next_prev" builder in
+    let _ = L.build_store prev next_prev builder in
+    let prev_next = L.build_struct_gep prev 6 "prev_next" builder in
+    let _ = L.build_store next prev_next builder in
+    let _ = L.build_free node builder in
+    ignore (L.build_ret_void builder); f
+  in
+
   (* Define each function (arguments and return type) so we can call it *)
   let function_decls =
     let function_decl m fdecl =
@@ -100,7 +166,22 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
         | None -> L.declare_function name
       in
       StringMap.add name (d_function name ftype the_module, fdecl) m in
-    List.fold_left function_decl StringMap.empty functions in
+    List.fold_left function_decl StringMap.empty functions
+  in
+
+  let gameobj_func_decls =
+    let func_decls g =     (* TODO: test *)
+      let open A.Gameobj in
+      let decl_fn (f_name, _) =
+        let name = g.name ^ "_" ^ f_name in
+        let llfn_t = L.function_type void_t [|ltype_of_typ (A.Object(g.name))|] in
+        (name, L.define_function name llfn_t the_module)
+      in
+      List.map decl_fn [("create", g.create); ("step", g.step); ("destroy", g.destroy); ("draw", g.draw)]
+    in
+    List.concat (List.map func_decls gameobjs)
+    |> List.fold_left (fun map (k, v) -> StringMap.add k v map) StringMap.empty
+  in
 
   (* Fill in the body of the given function *)
   let build_function_body the_function formals block return_type =
@@ -204,8 +285,23 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
           match fdecl.A.typ with A.Void -> "" | _ -> f ^ "_result"
         in
         L.build_call fdef (Array.of_list actuals) result builder
-      | A.Create _ -> failwith "not implemented"
-      | A.Destroy _ -> failwith "not implemented"
+      | A.Create objname ->
+        let (objtype, obj) = StringMap.find objname gameobj_types in
+        let llobj =
+          let o = L.build_malloc objtype objname builder in
+          L.build_bitcast o gameobj_t objname builder
+        in
+        let events =
+          ["create"; "step"; "destroy"; "draw"]
+          |> List.map (fun x ->
+              L.build_bitcast
+                (StringMap.find (objname ^ "_" ^ x) gameobj_func_decls)
+                eventptr_t
+                (objname ^ "_" ^ x)
+                builder)
+        in
+        L.build_call create_func (Array.of_list (llobj :: events)) obj.A.Gameobj.name builder
+      | A.Destroy e -> L.build_call destroy_func [|expr builder e|] "" builder
     in
 
     (* Invoke "f builder" if the current block doesn't already
@@ -277,49 +373,48 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
     | None -> ()
   in
 
-  let gameobj_fns g =     (* TODO: test *)
+  List.iter build_function functions;
+
+  let build_gameobj_fn g =
     let open A.Gameobj in
     let build_fn (f_name, block) =
       let name = g.name ^ "_" ^ f_name in
-      let llfn_t = L.function_type void_t [|ltype_of_typ (A.Object(g.name))|] in
-      let llfn = L.define_function name llfn_t the_module in
-      build_function_body llfn [A.Object(g.name), "this"] block A.Void; name, llfn
+      let llfn = StringMap.find name gameobj_func_decls in
+      build_function_body llfn [A.Object(g.name), "this"] block A.Void
     in
-    List.map build_fn [("create", g.create); ("step", g.step); ("destroy", g.destroy); ("draw", g.draw)]
+    List.iter build_fn [("create", g.create); ("step", g.step); ("destroy", g.destroy); ("draw", g.draw)]
   in
+  List.iter build_gameobj_fn gameobjs;
 
-  List.iter build_function functions;
+  let create_gb = L.define_function "global_create" (L.function_type void_t [||]) the_module in
+  build_function_body create_gb [] { A.locals = []; body = [A.Expr (A.Create "main")]} A.Void;
 
-  let gameobj_fns =
-    List.concat (List.map gameobj_fns gameobjs)
-    |> List.fold_left (fun map (k, v) -> StringMap.add k v map) StringMap.empty
-  in
-  let gameobj_fn o f =
-    let str =
-      let open A.Gameobj in
-      match f with Create -> "create" | Destroy -> "destroy" | Step -> "step" | Draw -> "draw"
-    in
-    StringMap.find (o ^ "_" ^ str) gameobj_fns
-  in
+  let global_event (name, offset) =
+    let step_gb = L.define_function ("global_" ^ name) (L.function_type void_t [||]) the_module in
+    let builder = L.builder_at_end context (L.entry_block step_gb) in
+    let node_ptr = L.build_alloca (L.pointer_type node_t) "node" builder in
+    let _ = L.build_store node_head node_ptr builder in
+    (* let _ = L.build_ret_void builder in *)
+    let pred_bb = L.append_block context "check" step_gb in
+    ignore (L.build_br pred_bb builder);
 
-  let random_fn = L.define_function "random" (L.function_type void_t [||]) the_module in
-  let builder = L.builder_at_end context (L.entry_block random_fn) in
-  let (main_t, _) = StringMap.find "main" gameobj_types in
-  let main_o =
-    L.define_global "main_o" (L.const_null main_t) the_module
+    let pred_builder = L.builder_at_end context pred_bb in
+    let curr = L.build_load node_ptr "cur_node" pred_builder in
+    let next = L.build_load (L.build_struct_gep curr 6 "" pred_builder) "next_ptr" pred_builder in
+    let _ = L.build_store next node_ptr pred_builder in
+    let diff = L.build_ptrdiff next node_head "diff" pred_builder in
+    let bool_val = L.build_icmp L.Icmp.Eq diff (L.const_null (L.i64_type context)) "cont" pred_builder in
+
+    let body_bb = L.append_block context "body" step_gb in
+    let body_builder = L.builder_at_end context body_bb in
+    let sf = L.build_load (L.build_struct_gep next offset "" body_builder) ("this_" ^ name) body_builder in
+    let _ = L.build_call sf [|next|] "" body_builder in
+    ignore (L.build_br pred_bb body_builder);
+
+    let merge_bb = L.append_block context "merge" step_gb in
+    ignore (L.build_cond_br bool_val merge_bb body_bb pred_builder);
+    ignore (L.build_ret_void (L.builder_at_end context merge_bb))
   in
-  let gfn = gameobj_fn "main" in
-  let main_obj =
-    let open A.Gameobj in
-    L.define_global "main_obj"
-      (L.const_struct context [|main_o; gfn Create; gfn Step; gfn Destroy; gfn Draw; L.const_null (L.pointer_type node_t); L.const_null (L.pointer_type node_t)|])
-      the_module
-  in
-  (* think about just having a single flat struct in case of inheritance *)
-  let ex = L.build_alloca node_t "ex_main" builder in
-  let ez = L.build_bitcast main_obj (L.pointer_type node_t) "ez" builder in
-  let ey = L.build_load ez "ey" builder in
-  ignore (L.build_store ey ex builder);
-  ignore (L.build_ret_void builder);
+  List.iter global_event ["step", 2; "draw", 4];
 
   the_module

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -53,7 +53,7 @@ let translate ((globals, functions, gameobjs) : Ast.program) =
     (* | A.Arr (typ, len) -> L.array_type (ltype_of_typ typ) len *)
     | A.Sprite -> sprite_t
     | A.Sound -> sound_t
-    | A.Object o -> L.pointer_type node_t (* let (t, _) = StringMap.find o gameobj_types in L.pointer_type t *)
+    | A.Object _ -> L.pointer_type node_t
     | A.Void -> void_t
   in
 

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -24,6 +24,7 @@ open Ast
 %left AND
 %left EQ NEQ
 %left LT GT LEQ GEQ
+%right CREATE DESTROY
 %left PLUS MINUS
 %left TIMES DIVIDE
 %left EXPONENT MODULO
@@ -144,6 +145,8 @@ expr:
   | NOT expr         { Unop(Not, Void, $2) }
   | id_chain ASSIGN expr   { Assign($1, $3) }
   | ID LPAREN actuals_opt RPAREN { Call($1, $3) }
+  | CREATE ID { Create($2) }
+  | DESTROY expr { Destroy($2) }
   | LPAREN expr RPAREN { $2 }
 
 id_chain:

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -126,22 +126,22 @@ expr:
   | TRUE             { BoolLit(true) }
   | FALSE            { BoolLit(false) }
   | id_chain         { Id(fst $1, snd $1) }
-  | expr PLUS   expr { Binop($1, Add,   $3) }
-  | expr MINUS  expr { Binop($1, Sub,   $3) }
-  | expr TIMES  expr { Binop($1, Mult,  $3) }
-  | expr DIVIDE expr { Binop($1, Div,   $3) }
-  | expr EXPONENT expr { Binop($1, Expo,   $3) }
-  | expr MODULO expr { Binop($1, Modulo,$3) }
-  | expr EQ     expr { Binop($1, Equal, $3) }
-  | expr NEQ    expr { Binop($1, Neq,   $3) }
-  | expr LT     expr { Binop($1, Less,  $3) }
-  | expr LEQ    expr { Binop($1, Leq,   $3) }
-  | expr GT     expr { Binop($1, Greater, $3) }
-  | expr GEQ    expr { Binop($1, Geq,   $3) }
-  | expr AND    expr { Binop($1, And,   $3) }
-  | expr OR     expr { Binop($1, Or,    $3) }
-  | MINUS expr %prec NEG { Unop(Neg, $2) }
-  | NOT expr         { Unop(Not, $2) }
+  | expr PLUS   expr { Binop($1, Add, Void,  $3) }
+  | expr MINUS  expr { Binop($1, Sub, Void,  $3) }
+  | expr TIMES  expr { Binop($1, Mult, Void, $3) }
+  | expr DIVIDE expr { Binop($1, Div, Void,  $3) }
+  | expr EXPONENT expr { Binop($1, Expo, Void,  $3) }
+  | expr MODULO expr { Binop($1, Modulo, Void,  $3) }
+  | expr EQ     expr { Binop($1, Equal, Void,   $3) }
+  | expr NEQ    expr { Binop($1, Neq, Void,  $3) }
+  | expr LT     expr { Binop($1, Less, Void, $3) }
+  | expr LEQ    expr { Binop($1, Leq, Void,  $3) }
+  | expr GT     expr { Binop($1, Greater, Void, $3) }
+  | expr GEQ    expr { Binop($1, Geq, Void,  $3) }
+  | expr AND    expr { Binop($1, And, Void,  $3) }
+  | expr OR     expr { Binop($1, Or, Void,   $3) }
+  | MINUS expr %prec NEG { Unop(Neg, Void,   $2) }
+  | NOT expr         { Unop(Not, Void, $2) }
   | id_chain ASSIGN expr   { Assign($1, $3) }
   | ID LPAREN actuals_opt RPAREN { Call($1, $3) }
   | LPAREN expr RPAREN { $2 }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -50,10 +50,10 @@ rule token = parse
   | "sprite" { SPRITE }
   | "sound"  { SOUND }
   (* game keywords *)
-  | "CREATE" { CREATE }
-  | "DESTROY" { DESTROY }
-  | "DRAW" { DRAW }
-  | "STEP" { STEP }
+  | "create" { CREATE }
+  | "destroy" { DESTROY }
+  | "draw" { DRAW }
+  | "step" { STEP }
   (* misc keywords *)
   | "extern" { EXTERN }
   (* literals *)

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -29,7 +29,7 @@ let check ((globals, functions, gameobjs) : Ast.program) =
   (* Raise an exception of the given rvalue type cannot be assigned to
      the given lvalue type *)
   let check_assign lvaluet rvaluet err =
-    if lvaluet == rvaluet then lvaluet else failwith err
+    if lvaluet = rvaluet then lvaluet else failwith err
   in
 
   (**** Checking Global Variables ****)
@@ -233,15 +233,15 @@ let check ((globals, functions, gameobjs) : Ast.program) =
   let check_gameobj ~symbols obj =
     let open Gameobj in
     let obj_fn_list obj =
-      [("create", Create, obj.create);
-       ("step", Step, obj.step);
-       ("draw", Draw, obj.draw);
-       ("destroy", Destroy, obj.destroy)]
+      [("create", Gameobj.Create, obj.create);
+       ("step", Gameobj.Step, obj.step);
+       ("draw", Gameobj.Draw, obj.draw);
+       ("destroy", Gameobj.Destroy, obj.destroy)]
     in
     report_duplicate
       (fun n -> "duplicate members " ^ n ^ " in " ^ obj.name)
       (List.map snd obj.members);
-    
+    let symbols = StringMap.add "this" (Object(obj.name)) symbols in
     let check_obj_fn (name, eventtype, block) =
       eventtype, check_block ~symbols ~name:(obj.name ^ "::" ^ name) ~return:Void block
     in

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -172,6 +172,11 @@ let check ((globals, functions, gameobjs) : Ast.program) =
                          " expected " ^ string_of_typ ft ^ " in " ^ string_of_expr ex)); ex')
             fd.formals actuals in
         fd.typ, Call(fname, actuals')
+      | Create(obj_type) -> Object((gameobj_decl obj_type).Gameobj.name), e
+      | Destroy(e) ->
+        match expr e with
+        | Object _, e' -> Void, Destroy(e')
+        | _ -> failwith ("cannot destroy non-object")
     in
 
     let check_bool_expr e = let (t, e') = expr e in if t != Bool


### PR DESCRIPTION
Oops, accidentally put my branch on top of the floating point one instead of the other way around... in any case it should be fine.

- Enabled `create` and `destroy` keywords through instantiating object structs with linked list connections. 
- Semant functions either return a 'fixed-up' version of the item they check (instead of just returning unit) or raise an exception.